### PR TITLE
Include the ability for acpype to determine the charge of ligand

### DIFF
--- a/biobb_chemistry/acpype/acpype_params_ac.py
+++ b/biobb_chemistry/acpype/acpype_params_ac.py
@@ -22,7 +22,7 @@ class AcpypeParamsAC():
         output_path_prmtop (str): Path to the PRMTOP output file. File type: output. `Sample file <https://github.com/bioexcel/biobb_chemistry/raw/master/biobb_chemistry/test/reference/acpype/ref_acpype.ac.prmtop>`_. Accepted formats: prmtop (edam:format_3881).
         properties (dic - Python dictionary object containing the tool parameters, not input/output files):
             * **basename** (*str*) - ("BBB") A basename for the project (folder and output files).
-            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0.
+            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0. If None the charge is guessed by acpype.
             * **acpype_path** (*str*) - ("acpype") Path to the acpype executable binary.
             * **remove_tmp** (*bool*) - (True) [WF property] Remove temporal files.
             * **restart** (*bool*) - (False) [WF property] Do not execute if output files exist.
@@ -127,9 +127,11 @@ class AcpypeParamsAC():
         basename = '-b ' + out_pth
         instructions_list.append(basename)
 
-        # adding charge
-        charge = '-n ' + get_charge(self.charge, out_log)
-        instructions_list.append(charge)
+        # adding charge if not none
+        charge = get_charge(self.charge, out_log)
+        if charge:
+            charge = '-n ' + charge
+            instructions_list.append(charge)
 
         return instructions_list
 

--- a/biobb_chemistry/acpype/acpype_params_cns.py
+++ b/biobb_chemistry/acpype/acpype_params_cns.py
@@ -21,7 +21,7 @@ class AcpypeParamsCNS():
         output_path_top (str): Path to the TOP output file. File type: output. `Sample file <https://github.com/bioexcel/biobb_chemistry/raw/master/biobb_chemistry/test/reference/acpype/ref_acpype.cns.top>`_. Accepted formats: top (edam:format_3881).
         properties (dic - Python dictionary object containing the tool parameters, not input/output files):
             * **basename** (*str*) - ("BBB") A basename for the project (folder and output files).
-            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0.
+            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0. If None the charge is guessed by acpype.
             * **acpype_path** (*str*) - ("acpype") Path to the acpype executable binary.
             * **remove_tmp** (*bool*) - (True) [WF property] Remove temporal files.
             * **restart** (*bool*) - (False) [WF property] Do not execute if output files exist.
@@ -123,9 +123,11 @@ class AcpypeParamsCNS():
         basename = '-b ' + out_pth
         instructions_list.append(basename)
 
-        # adding charge
-        charge = '-n ' + get_charge(self.charge, out_log)
-        instructions_list.append(charge)
+        # adding charge if not none
+        charge = get_charge(self.charge, out_log)
+        if charge:
+            charge = '-n ' + charge
+            instructions_list.append(charge)
 
         return instructions_list
 

--- a/biobb_chemistry/acpype/acpype_params_gmx.py
+++ b/biobb_chemistry/acpype/acpype_params_gmx.py
@@ -21,7 +21,7 @@ class AcpypeParamsGMX():
         output_path_top (str): Path to the TOP output file. File type: output. `Sample file <https://github.com/bioexcel/biobb_chemistry/raw/master/biobb_chemistry/test/reference/acpype/ref_acpype.gmx.top>`_. Accepted formats: top (edam:format_3880).
         properties (dic - Python dictionary object containing the tool parameters, not input/output files):
             * **basename** (*str*) - ("BBB") A basename for the project (folder and output files).
-            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0.
+            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0. If None the charge is guessed by acpype.
             * **acpype_path** (*str*) - ("acpype") Path to the acpype executable binary.
             * **remove_tmp** (*bool*) - (True) [WF property] Remove temporal files.
             * **restart** (*bool*) - (False) [WF property] Do not execute if output files exist.
@@ -123,9 +123,11 @@ class AcpypeParamsGMX():
         basename = '-b ' + out_pth
         instructions_list.append(basename)
 
-        # adding charge
-        charge = '-n ' + get_charge(self.charge, out_log)
-        instructions_list.append(charge)
+        # adding charge if not None
+        charge = get_charge(self.charge, out_log)
+        if charge:
+            charge = '-n ' + charge
+            instructions_list.append(charge)
 
         return instructions_list
 

--- a/biobb_chemistry/acpype/acpype_params_gmx_opls.py
+++ b/biobb_chemistry/acpype/acpype_params_gmx_opls.py
@@ -20,7 +20,7 @@ class AcpypeParamsGMXOPLS():
         output_path_top (str): Path to the TOP output file. File type: output. `Sample file <https://github.com/bioexcel/biobb_chemistry/raw/master/biobb_chemistry/test/reference/acpype/ref_acpype.gmx.opls.top>`_. Accepted formats: top (edam:format_3880).
         properties (dic - Python dictionary object containing the tool parameters, not input/output files):
             * **basename** (*str*) - ("BBB") A basename for the project (folder and output files).
-            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0.
+            * **charge** (*int*) - (0) [-20~20|1] Net molecular charge, for gas default is 0. If None the charge is guessed by acpype.
             * **acpype_path** (*str*) - ("acpype") Path to the acpype executable binary.
             * **remove_tmp** (*bool*) - (True) [WF property] Remove temporal files.
             * **restart** (*bool*) - (False) [WF property] Do not execute if output files exist.
@@ -119,9 +119,11 @@ class AcpypeParamsGMXOPLS():
         basename = '-b ' + out_pth
         instructions_list.append(basename)
 
-        # adding charge
-        charge = '-n ' + get_charge(self.charge, out_log)
-        instructions_list.append(charge)
+        # adding charge if not none
+        charge = get_charge(self.charge, out_log)
+        if charge:
+            charge = '-n ' + charge
+            instructions_list.append(charge)
 
         return instructions_list
 

--- a/biobb_chemistry/acpype/common.py
+++ b/biobb_chemistry/acpype/common.py
@@ -53,15 +53,15 @@ def get_charge(charge, out_log):
 		fu.log('No charge provided, default value %s assigned' % get_default_value('charge'), out_log)
 		ch = get_default_value('charge')
 
+	if ch is None:
+		fu.log('Charge will be guessed by acpype.', out_log)
+		return ch
+
 	if not isinstance(ch, (int,None) ):
 		fu.log('Value %s is not compatible as a charge value, default value %d assigned' % (ch, get_default_value('charge')), out_log)
 		ch = get_default_value('charge')
 
-	if ch is None:
-		fu.log('Charge will be guessed by acpype.', out_log)
-		return ch
-	else:
-		return str(ch)
+	return str(ch)
 
 def create_unique_name(length = 10, char = string.ascii_uppercase +
                           string.digits +           

--- a/biobb_chemistry/acpype/common.py
+++ b/biobb_chemistry/acpype/common.py
@@ -53,11 +53,15 @@ def get_charge(charge, out_log):
 		fu.log('No charge provided, default value %s assigned' % get_default_value('charge'), out_log)
 		ch = get_default_value('charge')
 
-	if not isinstance(ch, int):
+	if not isinstance(ch, (int,None) ):
 		fu.log('Value %s is not compatible as a charge value, default value %d assigned' % (ch, get_default_value('charge')), out_log)
 		ch = get_default_value('charge')
 
-	return str(ch)
+	if ch is None:
+		fu.log('Charge will be guessed by acpype.', out_log)
+		return ch
+	else:
+		return str(ch)
 
 def create_unique_name(length = 10, char = string.ascii_uppercase +
                           string.digits +           


### PR DESCRIPTION
Current implementation does not allow any of the acpype utilities to leave out the charge option (-n ) thus it is not possible to have acpype determine the charge.

In this implementation charge key in properties dictionary can be provided None as an argument which will then start acpype without charge argument which in turn then makes acpype determine the charge of the system (often with decent results). The documentation has been updated accordingly.

Default charge of 0 was left as is, although it might make sense at some point to change it to None, as such option could be slightly more intuitive.